### PR TITLE
fix: use vec4 for export call

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -41,8 +41,7 @@ CreateThread(function()
         EndTextCommandSetBlipName(blips[_])
         npc = exports['rep-talkNPC']:CreateNPC({
             npc = info.ped.hash,
-            coords = vector3(info.coords.x, info.coords.y, info.coords.z),
-            heading = info.coords.w,
+            coords = vector3(info.coords.x, info.coords.y, info.coords.z, info.coords.w),
             name = info.ped.name,
             animScenario = 'WORLD_HUMAN_CLIPBOARD',
             position = info.ped.position,


### PR DESCRIPTION
rep-talkNPC CreateNPC export doesn't do anything with heading. It looks for it in the vec4 coords. This fixes that issue.